### PR TITLE
Fixes to Signature

### DIFF
--- a/src/oauth/client.clj
+++ b/src/oauth/client.clj
@@ -85,10 +85,11 @@ to approve the Consumer's access to their account."
   ([consumer request-token]
      (access-token consumer request-token nil))
   ([consumer request-token verifier]
-     (let [unsigned-params (sig/oauth-params consumer request-token verifier)
+     (let [unsigned-params (sig/oauth-params consumer (:oauth_token request-token) verifier)
            signature (sig/sign consumer (sig/base-string "POST"
                                                          (:access-uri consumer)
-                                                         unsigned-params))
+                                                         unsigned-params)
+                               (:oauth_token_secret request-token))
            params (assoc unsigned-params :oauth_signature signature)]
        (success-content
         (http/post (:access-uri consumer)

--- a/src/oauth/signature.clj
+++ b/src/oauth/signature.clj
@@ -49,7 +49,7 @@
 
 (defmethod sign :plaintext
   [c base-string & [token-secret]]
-  (str (url-encode (c :secret)) "&" (url-encode token-secret)))
+  (str (url-encode (:secret c)) "&" (url-encode (or token-secret ""))))
 
 (defn verify [sig digest-method c base-string & [token-secret]]
   (= sig (sign digest-method c base-string token-secret)))
@@ -73,7 +73,7 @@ requires RFC 3986 encoding."
   "Build a map of parameters needed for OAuth requests."
   ([consumer]
      {:oauth_consumer_key (:key consumer)
-      :oauth_signature_method "HMAC-SHA1"
+      :oauth_signature_method (signature-methods (:signature-method consumer))
       :oauth_timestamp (System/currentTimeMillis)
       :oauth_nonce (rand-str 30)
       :oauth_version "1.0"})


### PR DESCRIPTION
I had some problems getting clj-oauth to work correctly with the yammer api. I tracked it down with a yammer api engineer, and the problem was that the request-token secret wasn't being passed to the sign method. I had to change the `access-token` method so that it takes the entire request-token map (:oauth_token and :oauth_token_secret) so it could pass the secret into `sign`. I also fixed the PLAINTEXT signature method, as it was causing a NullPointerException.

Thanks,
Justin
