### PR TITLE
fix query string for user-approval-uri

### DIFF
--- a/src/oauth/client.clj
+++ b/src/oauth/client.clj
@@ -88,7 +88,7 @@
 to approve the Consumer's access to their account."
   [consumer token]
   (.toString (http/resolve-uri (:authorize-uri consumer) 
-                               {:oauth_token token})))
+                               {:oauth_token (:oauth_token token)})))
 
 (defn access-token 
   "Exchange a request token for an access token.


### PR DESCRIPTION
The url included all values from the request token should just be the oauth_token
