### PR TITLE
Update for clojure v1.3

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,4 +1,4 @@
-(defproject clj-oauth "1.2.10-SNAPSHOT"
+(defproject clj-oauth "1.2.11-SNAPSHOT"
   :description "OAuth support for Clojure"
   :dependencies [[org.clojure/clojure "1.3.0"]
                  [com.twinql.clojure/clj-apache-http "2.3.1"]


### PR DESCRIPTION
Hey Matt,

I updated this library to support clojure v1.3. This patch will work as long as Richard (rnewman) (updates his clj-apache-http project)[https://github.com/rnewman/clj-apache-http/pull/12].

I also took the liberty to remove the swank-clojure from :dev-dependencies, the reasons are stated in the commit.

Cheers.

Roman.- 
