### PR TITLE
Update test to match api change

### DIFF
--- a/test/oauth/client_twitter_test.clj
+++ b/test/oauth/client_twitter_test.clj
@@ -19,7 +19,7 @@
 (deftest
     #^{:doc "Considered to pass if no exception is thrown."}
   user-approval-uri
-  (is (instance? String (oc/user-approval-uri consumer (oc/request-token consumer)))))
+  (is (instance? String (oc/user-approval-uri consumer (:oauth_token (oc/request-token consumer))))))
 
 #_(deftest
     #^{:doc "Considered to pass if no exception is thrown."}


### PR DESCRIPTION
Hello Matt, 

Apparently the parameter format changed on user-approval-uri, but the tests didn't reflect this.
I noticed this while working on a [fork using Aleph/Lamina](https://github.com/mpenet/clj-oauth/tree/aleph-http-client) instead of clj-http in case you might be interested. 
