### PR TITLE
update README to use clj-http instead of clj-apache-http

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -59,11 +59,9 @@ The server support makes it simple to add OAuth support to any [Ring](http://git
                                         "http://twitter.com/statuses/update.json"
                                         {:status "posting from #clojure with #oauth")))
 
-    ;; Post with clj-apache-http...
+    ;; Post with clj-http...
     (http/post "http://twitter.com/statuses/update.json" 
-               :query (merge credentials 
-                             {:status "posting from #clojure with #oauth"})
-               :parameters (http/map->params {:use-expect-continue false})))
+               :query-params credentials)
                                          
     ;; ...or with clojure-twitter (http://github.com/mattrepl/clojure-twitter)
     (require 'twitter)


### PR DESCRIPTION
Since clj-oauth itself uses `clj-http`, I thought it was only appropriate that the README be updated to use clj-http instead of clj-apache-http.

I haven't tested the example code with Twitter's API, but it worked for Dropbox's. 
