### PR TITLE
Allow extra params when constructing user approval URI

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -1,6 +1,7 @@
 (defproject clj-oauth "1.5.0"
   :description "OAuth support for Clojure"
   :dependencies [[org.clojure/clojure "1.5.0"]
+                 [bouncycastle/bcprov-jdk16 "140"]
                  [commons-codec/commons-codec "1.8"]
                  [clj-http "0.9.1"]]
   :min-lein-version "2.0.0")

--- a/src/oauth/client.clj
+++ b/src/oauth/client.clj
@@ -24,9 +24,11 @@
 (defn user-approval-uri
   "Builds the URI to the Service Provider where the User will be prompted
 to approve the Consumer's access to their account."
-  [consumer token]
-  (str (:authorize-uri consumer)
-       "?" (httpclient/generate-query-string {:oauth_token token})))
+  ([consumer token]
+   (user-approval-uri consumer token {}))
+  ([consumer token extra-params]
+   (str (:authorize-uri consumer)
+        "?" (httpclient/generate-query-string (merge {:oauth_token token} extra-params)))))
 
 (defn authorization-header
   "OAuth credentials formatted for the Authorization HTTP header."


### PR DESCRIPTION
Allow user to specify extra params when constructiing approval URI.
Specific use case is the "force_login" option in the Twitter authentication flow.

See #30 