### PR TITLE
Corresponding exceptions from clj-http.

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -4,8 +4,8 @@
             :url "https://opensource.org/licenses/BSD-2-Clause"
             :distribution :repo}
   :description "OAuth support for Clojure"
-  :dependencies [[org.clojure/clojure "1.7.0"]
-                 [commons-codec/commons-codec "1.8"]
-                 [org.bouncycastle/bcprov-jdk15on "1.54"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.54"]
-                 [clj-http "2.0.1"]])
+  :dependencies [[org.clojure/clojure "1.8.0"]
+                 [commons-codec/commons-codec "1.10"]
+                 [org.bouncycastle/bcprov-jdk15on "1.55"]
+                 [org.bouncycastle/bcpkix-jdk15on "1.55"]
+                 [clj-http "3.4.1"]])

--- a/test/oauth/client_twitter_test.clj
+++ b/test/oauth/client_twitter_test.clj
@@ -1,7 +1,9 @@
 (ns oauth.client-twitter-test
   (:refer-clojure :exclude [key])
-  (:require [oauth.client :as oc])
+  (:require [oauth.client :as oc]
+            [oauth.signature :refer [oauth-params signature-methods]])
   (:use clojure.test)
+  (:import [clojure.lang ExceptionInfo])
   (:load "twitter_keys"))
 
 (def consumer (oc/make-consumer key
@@ -13,8 +15,81 @@
 (deftest
     #^{:doc "Test requesting a token from Twitter.
             Considered to pass if no exception is thrown."}
-  request-token
-  (oc/request-token consumer))
+  request-token-success-test
+  (is (= 200
+         (:status (oc/request-token consumer)))
+      "Twitter has regarded your application as web application.")
+  (is (= 200
+         (:status (oc/request-token consumer "http://localhost/")))
+      "Twitter has regarded your application as desktop application."))
+
+(deftest
+  ^{:doc "Test requesting a token from Twitter.
+         Considered to pass if some exception is thrown."}
+  request-token-error-test
+  (testing "When consumer has not been passed."
+    (is (thrown-with-msg? ExceptionInfo
+                          #"clj-http: status 400"
+                          (oc/request-token nil))
+        "Calling request_token has been passed but header has not set.")
+    (is (thrown-with-msg? ExceptionInfo
+                          #"clj-http: status 400"
+                          (oc/request-token nil "http://localhost/"))
+        "Calling request_token has been passed but header has not set."))
+  (testing "When consumer is passed but oauth_timestamp is invalid. (timestamp = -1)"
+    (with-redefs [oauth-params (fn
+                                  ([consumer nonce _]
+                                   {:oauth_consumer_key (:key consumer)
+                                    :oauth_signature_method (sig/signature-methods (:signatue-method consumer))
+                                    :oauth_timestamp -1
+                                    :oauth_nonce nonce
+                                    :oauth_version "1.0"})
+                                  ([consumer nonce _ token]
+                                   (assoc (oauth-params consumer nonce nil)
+                                          :oauth_token token))
+                                  ([consumer nonce _ token verifier]
+                                   (assoc (oauth-params consumer nonce nil token)
+                                          :oauth_verifier verifier)))]
+      (is (thrown-with-msg? ExceptionInfo
+                            #"clj-http: status 401"
+                            (oc/request-token consumer))
+          "oauth_timestamp has been passed but is invalid.")
+      (is (thrown-with-msg? ExceptionInfo
+                            #"clj-http: status 401"
+                            (oc/request-token consumer "http://localhost/"))
+          "oauth_timestamp has been passed but is invalid.")))
+  (testing "When consumer key, Consumer secret or both is incorrect:"
+    (let [request-uri "https://api.twitter.com/oauth/request_token"
+          access-uri "https://api.twitter.com/oauth/access_token"
+          authorize-uri "https://api.twitter.com/oauth/authorize"
+          signature-method :hmac-sha1]
+      (is (thrown-with-msg? ExceptionInfo
+                            #"clj-http: status 401"
+                            (oc/request-token (oc/make-consumer nil
+                                                                nil
+                                                                request-uri
+                                                                access-uri
+                                                                authorize-uri
+                                                                signature-method)))
+          "Request Token has been responded but Consumer Key and Consumer Secret are nil.")
+      (is (thrown-with-msg? ExceptionInfo
+                            #"clj-http: status 401"
+                            (oc/request-token (oc/make-consumer key
+                                                                nil
+                                                                request-uri
+                                                                access-uri
+                                                                authorize-uri
+                                                                signature-method)))
+          "Request Token has been responded but Consumer Secret is nil.")
+      (is (thrown-with-msg? ExceptionInfo
+                            #"clj-http: status 401"
+                            (oc/request-token (oc/make-consumer nil
+                                                                secret
+                                                                request-uri
+                                                                access-uri
+                                                                authorize-uri
+                                                                signature-method)))
+          "Request Token has been responded but Consumer Key is nil."))))
 
 (deftest
     #^{:doc "Considered to pass if no exception is thrown."}


### PR DESCRIPTION
Hi, @mattrepl .
First, Thank you for this useful library for OAuth with Clojure-life. :)
I'm using this to connect between my web application to Twitter APIs.
But I cared following points:

## Corresponding the response body for clj-http
The HTTP request functions of clj-http will throw ExceptionInfo via slingshot.

```clj
(defn- exceptions-response
  [req {:keys [status] :as resp}]
    (if (unexceptional-status? status)
      resp
      (if (false? (opt req :throw-exceptions))
        resp
       (if (opt req :throw-entire-message)
         (throw+ resp "clj-http: status %d %s" (:status %) resp)
         (throw+ resp "clj-http: status %s" (:status %))))))
```

`throw+` is just it.
Note that clj-http will throw this exception when status code is just 4xx or 5xx.
But current clj-oauth has thrown Exception even if status code is over 300...
The status code 3xx is **redirect**. It is not error.

```clj
(defn- check-success-response [m]
  (let [code (:status m)]
    (if (or (< code 200)
                (>= code 300))
      (throw (new Exception (str "Got non-success code: " code ". "
                                                       "Content: " (:body m))))
      m)))
```

This is not so good because errors from clj-http has been replaced other errors.
I thought better We follow errors from clj-http because it is doing well currently.
Therefore this code will not be needed.

## Not ignoring other fields

```clj
(defn post-request-body-decoded [url & [req]]
  (form-decode
   (:body (check-success-response
    (httpclient/post url req)))))
```

Why did you ignore other fields? Those should not be ignored because are also needed for HTTP connections.
If we need to decode response body, this should be written following code instead:

```clj
(defn post-request-body-decoded
  [url & [req]]
  (let [res (httpclient/post url req)]
    (update res
                  :body
                  (form-decode (:body res)))))
```


Finally, I'll repeat that clj-oauth is very useful library. ;)