### PR TITLE
security: bump BouncyCastle jdk15on 1.70 → jdk18on 1.80

### DIFF
--- a/project.clj
+++ b/project.clj
@@ -6,6 +6,6 @@
   :description "OAuth support for Clojure"
   :dependencies [[org.clojure/clojure "1.10.3"]
                  [commons-codec/commons-codec "1.15"]
-                 [org.bouncycastle/bcprov-jdk15on "1.70"]
-                 [org.bouncycastle/bcpkix-jdk15on "1.70"]
+                 [org.bouncycastle/bcprov-jdk18on "1.80"]
+                 [org.bouncycastle/bcpkix-jdk18on "1.80"]
                  [clj-http "3.12.3"]])

--- a/test/oauth/signature_test.clj
+++ b/test/oauth/signature_test.clj
@@ -216,19 +216,19 @@
 (deftest rsa-sha1-signature
   (let [c {:secret
            "-----BEGIN RSA PRIVATE KEY-----
-           MIIBOwIBAAJBAPwrtgkaYAbp/xzfBzcsZR/ADW1ZVsRG6JOou8AcFM/gvuPOxXVk
-           5zhs+rTk19UO53XO9cHOFd4HwndY/Y7tcOMCAwEAAQJBAKqRQnML1RI4Kqgzr2TB
-           cbE1LZ/eQxNGR0DBbCV4mRc1vRAZ6Y/lbVEm7snA6CYsTALr5ajoCQgL3DReCMhj
-           rbkCIQD+sDIWPIx+zCLJ+1mFk9dt48EFFQNHjfPhMXdeIohetwIhAP14MjN/4jlj
-           V8d9H0WILt/1xCHcneNojYACVGxRZ9M1AiARwoObnVlGtkFuyEIz2F1bYlhhXFfA
-           M5vgBi0GuW28/QIgGU83NA1A+ZoB2dmUlczTYWmY/Aibe2mlN3MEGwzF4UECIQCa
-           YRd7U3DJo60QR8zRepaqOILLwtkpxoauNOYx35vF/Q==
-           -----END RSA PRIVATE KEY-----"
+MIIBOwIBAAJBAPwrtgkaYAbp/xzfBzcsZR/ADW1ZVsRG6JOou8AcFM/gvuPOxXVk
+5zhs+rTk19UO53XO9cHOFd4HwndY/Y7tcOMCAwEAAQJBAKqRQnML1RI4Kqgzr2TB
+cbE1LZ/eQxNGR0DBbCV4mRc1vRAZ6Y/lbVEm7snA6CYsTALr5ajoCQgL3DReCMhj
+rbkCIQD+sDIWPIx+zCLJ+1mFk9dt48EFFQNHjfPhMXdeIohetwIhAP14MjN/4jlj
+V8d9H0WILt/1xCHcneNojYACVGxRZ9M1AiARwoObnVlGtkFuyEIz2F1bYlhhXFfA
+M5vgBi0GuW28/QIgGU83NA1A+ZoB2dmUlczTYWmY/Aibe2mlN3MEGwzF4UECIQCa
+YRd7U3DJo60QR8zRepaqOILLwtkpxoauNOYx35vF/Q==
+-----END RSA PRIVATE KEY-----"
            :key
            "-----BEGIN PUBLIC KEY-----
-           MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAPwrtgkaYAbp/xzfBzcsZR/ADW1ZVsRG
-           6JOou8AcFM/gvuPOxXVk5zhs+rTk19UO53XO9cHOFd4HwndY/Y7tcOMCAwEAAQ==
-           -----END PUBLIC KEY-----"
+MFwwDQYJKoZIhvcNAQEBBQADSwAwSAJBAPwrtgkaYAbp/xzfBzcsZR/ADW1ZVsRG
+6JOou8AcFM/gvuPOxXVk5zhs+rTk19UO53XO9cHOFd4HwndY/Y7tcOMCAwEAAQ==
+-----END PUBLIC KEY-----"
            :signature-method :rsa-sha1}]
     (is (= (str "bLsgZgdgVNNmL0Gc7yjrG6L8YRpYOu1nB1cSKZVIcpjWjWK6GYLo7p9m0/"
                 "KTWtS0+1PfdVCSG6CY9Vc1pI59Sg==")


### PR DESCRIPTION
The `bcprov-jdk15on`/`bcpkix-jdk15on` artifacts are retired, and 1.70 carries CVE-2023-33201 plus later BouncyCastle advisories. This moves to the maintained `jdk18on` line at 1.80.

BC 1.80's `PemReader` rejects the leading whitespace that 1.70 tolerated, so the indented PEM literals in the `rsa-sha1-signature` test are dedented. RSA-SHA1 signing is deterministic, so the expected signature vector is unchanged - the existing test is the safety net for the swap.

Refs #56.