### PR TITLE
ci: add GitHub Actions test matrix

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,32 @@
+name: test
+
+on:
+  push:
+    branches: [master]
+  pull_request:
+    branches: [master]
+
+jobs:
+  test:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        jdk: ['8', '11', '17', '21']
+    steps:
+      - uses: actions/checkout@v4
+      - uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: ${{ matrix.jdk }}
+      - uses: DeLaGuardo/setup-clojure@13.4
+        with:
+          lein: 2.12.0
+      - uses: actions/cache@v4
+        with:
+          path: ~/.m2/repository
+          key: ${{ runner.os }}-m2-${{ hashFiles('project.clj') }}
+          restore-keys: ${{ runner.os }}-m2-
+      # Default selector runs the deterministic unit subset; the live Twitter
+      # integration tests are excluded (they need real credentials).
+      - run: lein test

--- a/project.clj
+++ b/project.clj
@@ -8,4 +8,7 @@
                  [commons-codec/commons-codec "1.15"]
                  [org.bouncycastle/bcprov-jdk15on "1.70"]
                  [org.bouncycastle/bcpkix-jdk15on "1.70"]
-                 [clj-http "3.12.3"]])
+                 [clj-http "3.12.3"]]
+  :test-selectors {:default (complement :integration)
+                   :integration :integration
+                   :all (constantly true)})

--- a/test/oauth/client_twitter_test.clj
+++ b/test/oauth/client_twitter_test.clj
@@ -1,8 +1,14 @@
 (ns oauth.client-twitter-test
   (:refer-clojure :exclude [key])
   (:require [oauth.client :as oc])
-  (:use clojure.test)
-  (:load "twitter_keys"))
+  (:use clojure.test))
+
+;; Live Twitter credentials for the ^:integration tests below. Read from the
+;; environment so this namespace always compiles without a credentials file.
+;; Run `lein test :integration` with TWITTER_CONSUMER_KEY and
+;; TWITTER_CONSUMER_SECRET set to exercise these against the live Twitter API.
+(def key (System/getenv "TWITTER_CONSUMER_KEY"))
+(def secret (System/getenv "TWITTER_CONSUMER_SECRET"))
 
 (def consumer-hmac-sha1 (oc/make-consumer key
                                 secret

--- a/test/oauth/client_twitter_test.clj
+++ b/test/oauth/client_twitter_test.clj
@@ -11,12 +11,14 @@
                                 "https://api.twitter.com/oauth/authorize"
                                 :hmac-sha1))
 (deftest
+    ^:integration
     #^{:doc "Test requesting a token from Twitter.
             Considered to pass if no exception is thrown."}
     hmac-sha1-request-token-test
   (oc/request-token consumer-hmac-sha1))
 
 (deftest
+    ^:integration
     #^{:doc "Considered to pass if no exception is thrown."}
     hmac-sha1-user-approval-uri-test
   (is (instance? String (oc/user-approval-uri consumer-hmac-sha1 (:oauth_token (oc/request-token consumer-hmac-sha1))))))
@@ -28,12 +30,14 @@
                                   "https://api.twitter.com/oauth/authorize"
                                   :hmac-sha256))
 (deftest
+    ^:integration
     #^{:doc "Test requesting a token from Twitter.
             Considered to pass if no exception is thrown."}
     hmac-sha256-request-token-test
   (oc/request-token consumer-hmac-sha256))
 
 (deftest
+    ^:integration
     #^{:doc "Considered to pass if no exception is thrown."}
     hmac-sha256-user-approval-uri-test
   (is (instance? String (oc/user-approval-uri consumer-hmac-sha256 (:oauth_token (oc/request-token consumer-hmac-sha256))))))


### PR DESCRIPTION
Adds CI: JDK 8/11/17/21 matrix running `lein test`.

To make the suite CI-runnable it also isolates the live Twitter integration tests: `oauth.client-twitter-test` hits the real Twitter API and required a local gitignored creds file, which made a bare `lein test` fail to compile the whole suite. Those four tests are tagged `^:integration` with a default `:test-selectors` that excludes them, so `lein test` runs the deterministic unit subset (signature/client/xauth) and `lein test :integration` runs the live ones (now reading creds from env, so secrets work in CI).